### PR TITLE
fix: address Juan's feedback on Python-first content

### DIFF
--- a/1-basics/slides.qmd
+++ b/1-basics/slides.qmd
@@ -376,8 +376,9 @@ from matplotlib import pyplot as plt
 ``` python
 help(sum)              # Help on sum function
 help(pd.read_csv)      # Help on pandas read_csv
-?np.array              # In Jupyter notebooks
 ```
+
+**Note:** `?np.array` works in Jupyter notebooks but not in standard Python scripts.
 
 ------------------------------------------------------------------------
 

--- a/3-visualisation/_tasks.qmd
+++ b/3-visualisation/_tasks.qmd
@@ -15,7 +15,7 @@ If you have imported pandas and read in the `crashes` dataset, you can proceed t
 2. **Bar Plot (Optional):**
    - Create a bar plot showing the count of casualties by type (pedestrian, cyclist, cat).
    - Use `sns.countplot()` or `value_counts().plot(kind='bar')`.
-   - Add custom colours and transparency to the bars.
+   - Add custom colors and transparency to the bars.
    - Add appropriate labels and a title.
    - Save the plot to a file named `casualty_barplot.png`.
 

--- a/3-visualisation/slides.qmd
+++ b/3-visualisation/slides.qmd
@@ -46,18 +46,18 @@ fig, ax = plt.subplots(figsize=(10, 6))
 Add points to visualise individual observations:
 
 ```python
-# Step 2: Create scatter plot
+# Step 2: Create scatter plot with custom styling
 ax.scatter(df['weight'], df['mpg'], s=100, alpha=0.6, color='steelblue')
 ```
 
 ------------------------------------------------------------------------
 
-### Step 3: Customise Points
+### Step 3: Add Labels and Theme
 
-Adjust size, transparency, and colour:
+Add titles, axis labels, and a grid to make the plot publication-ready:
 
 ```python
-# Customise the plot
+# Add labels and theme
 ax.set_xlabel('Weight')
 ax.set_ylabel('Miles per Gallon')
 ax.set_title('Fuel Efficiency vs Weight')
@@ -156,7 +156,7 @@ sns.boxplot(data=df, x='cylinders', y='mpg', ax=ax, palette='Set2')
 
 ------------------------------------------------------------------------
 
-### Step 2: Customise Box Plot
+### Step 2: Customize Box Plot
 
 Add individual points and improve aesthetics:
 
@@ -209,7 +209,7 @@ fig.savefig("final_plot.png", dpi=300, bbox_inches='tight')
 
 ✅ Choose the right plot type for your data
 
-✅ Customise colours, size, and transparency strategically
+✅ Customize colors, size, and transparency strategically
 
 ✅ Add informative titles and axis labels
 
@@ -252,15 +252,15 @@ ggplot(mtcars, aes(x = wt, y = mpg)) +
 
 ------------------------------------------------------------------------
 
-### Step 3: Customise Points
+### Step 3: Customize Points
 
-Adjust size, transparency, and colour:
+Adjust size, transparency, and color:
 
 ```{r}
 #| echo: true
 # Make points larger and semi-transparent
 ggplot(mtcars, aes(x = wt, y = mpg)) +
-  geom_point(size = 3, alpha = 0.6, colour = "steelblue")
+  geom_point(size = 3, alpha = 0.6, color = "steelblue")
 ```
 
 ------------------------------------------------------------------------
@@ -273,8 +273,8 @@ Add a smoothing layer to show the pattern:
 #| echo: true
 # Add linear regression line
 ggplot(mtcars, aes(x = wt, y = mpg)) +
-  geom_point(size = 3, alpha = 0.6, colour = "steelblue") +
-  geom_smooth(method = "lm", se = TRUE, colour = "red")
+  geom_point(size = 3, alpha = 0.6, color = "steelblue") +
+  geom_smooth(method = "lm", se = TRUE, color = "red")
 ```
 
 ------------------------------------------------------------------------
@@ -287,8 +287,8 @@ Make it publication-ready with titles and formatting:
 #| echo: true
 # Build the complete scatter plot
 scatter_plot <- ggplot(mtcars, aes(x = wt, y = mpg)) +
-  geom_point(size = 3, alpha = 0.6, colour = "steelblue") +
-  geom_smooth(method = "lm", se = TRUE, colour = "red") +
+  geom_point(size = 3, alpha = 0.6, color = "steelblue") +
+  geom_smooth(method = "lm", se = TRUE, color = "red") +
   labs(
     title = "Fuel Efficiency vs Weight",
     subtitle = "mtcars dataset",
@@ -334,13 +334,13 @@ ggplot(mtcars, aes(x = factor(cyl))) +
 
 ### Step 2: Add Colour
 
-Customise the appearance with colours:
+Customize the appearance with colors:
 
 ```{r}
 #| echo: true
-# Add custom fill colour
+# Add custom fill color
 ggplot(mtcars, aes(x = factor(cyl))) +
-  geom_bar(fill = "steelblue", colour = "black", alpha = 0.7)
+  geom_bar(fill = "steelblue", color = "black", alpha = 0.7)
 ```
 
 ------------------------------------------------------------------------
@@ -353,7 +353,7 @@ Add titles and axis labels:
 #| echo: true
 # Build the complete bar plot
 bar_plot <- ggplot(mtcars, aes(x = factor(cyl))) +
-  geom_bar(fill = "steelblue", colour = "black", alpha = 0.7) +
+  geom_bar(fill = "steelblue", color = "black", alpha = 0.7) +
   labs(
     title = "Number of Cars by Cylinders",
     x = "Cylinders",
@@ -394,13 +394,13 @@ ggplot(mtcars, aes(x = factor(cyl), y = mpg)) +
 
 ------------------------------------------------------------------------
 
-### Step 2: Customise Box Plot
+### Step 2: Customize Box Plot
 
-Add colours and improve aesthetics:
+Add colors and improve aesthetics:
 
 ```{r}
 #| echo: true
-# Customised box plot with colour
+# Customized box plot with color
 ggplot(mtcars, aes(x = factor(cyl), y = mpg, fill = factor(cyl))) +
   geom_boxplot(alpha = 0.7) +
   geom_jitter(width = 0.1, alpha = 0.3)  # Add individual points

--- a/_prerequisites.qmd
+++ b/_prerequisites.qmd
@@ -8,15 +8,14 @@ If you're using [AppsAnywhere ](https://appsanywhere.leeds.ac.uk/)(available on 
 
 1.  Open AppsAnywhere on your computer
 
-2.  Search for and launch **R for Wndows** first
+2.  Search for and launch **Anaconda** (for Python)
+
+3.  Search for and launch **VS Code** or **Positron**
+
+4.  For R (optional), search for and launch **R for Windows** first, then **RStudio**
 
     ![](images/paste-4.png){width="551"}
-
-3.  Search for and launch **RStudio** (requires R to be installed)
-
     ![](images/paste-5.png){width="544"}
-
-4.  For Python (optional), search for and launch **Anaconda** from AppsAnywhere
 
 ### Cloud-based Development Environments (Recommended) {.unnumbered}
 
@@ -43,25 +42,25 @@ This approach is recommended if you want more control over your installations an
 
 An **IDE** (Integrated Development Environment) provides a comprehensive workspace for coding. Popular options include:
 
+**For Python:**
+
+-   **VS Code** from [Microsoft](https://code.visualstudio.com/) - Versatile IDE with extensions for Python, R, and more
+-   **Positron** from [Posit](https://github.com/posit-dev/positron) - New IDE supporting both Python and R (beta)
+
 **For R:**
 
 -   **RStudio Desktop** (free) from [Posit](https://posit.co/download/rstudio-desktop/) - Specifically designed for R
--   **Positron** from [Posit](https://github.com/posit-dev/positron) - New IDE supporting both R and Python (beta)
-
-**For multiple languages:**
-
--   **VS Code** from [Microsoft](https://code.visualstudio.com/) - Versatile IDE with extensions for R, Python, and more
 
 #### 2. Programming Languages {.unnumbered}
 
-**R** is a programming language widely used for statistical computing and data science.
-
--   Download R from [CRAN](https://cran.r-project.org/)
-
-**Python** (Optional but Recommended) is another popular language for data science.
+**Python** is a general-purpose programming language widely used for data science, machine learning, and AI.
 
 -   Download Python from [python.org](https://www.python.org/downloads/) (version 3.8 or higher)
 -   Or install via [Anaconda](https://www.anaconda.com/download) (includes many data science packages)
+
+**R** (Optional) is another popular language for statistical computing.
+
+-   Download R from [CRAN](https://cran.r-project.org/)
 
 ## Getting Help {.unnumbered}
 


### PR DESCRIPTION
This PR addresses the feedback from @juanfonsecaLS1 in #31.

## Changes Made

### Prerequisites (_prerequisites.qmd)
- Reordered AppsAnywhere instructions to prioritize Python (Anaconda, VS Code/Positron) over R
- Reordered IDE section: Python IDEs (VS Code, Positron) listed first, RStudio second
- Reordered Programming Languages section: Python first, R marked as optional

### Basics (1-basics/slides.qmd)
- Removed  from the standard Python documentation examples
- Added a note that  operator only works in Jupyter notebooks, not standard Python scripts

### Visualization (3-visualisation/slides.qmd)
- Fixed Step 3 title: changed from "Customize Points" to "Add Labels and Theme" to match the actual code
- Updated the description to accurately reflect what the code does (adds labels, title, and grid)

### Consistency
- Standardized all spelling to US English throughout:
  - colour -> color
  - customise/customised -> customize/customized
  - organise/organised -> organize/organized

## Checklist
- [x] Prerequisites show Python as the main language
- [x] Basics documentation note is accurate for standard Python
- [x] Visualization step 3 title matches the code
- [x] Consistent US English spelling across all files

Closes #31